### PR TITLE
Remove misleading comment

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@ function frameSetup(width, height, pixelFormat)
 {
     console.log( width, height, pixelFormat );
     canvas = glCanvas();
-     // TODO: re-init on video change or window re-size
+
     canvas.width = width;
     canvas.height = height; 
     


### PR DESCRIPTION
This comment was written because I thought this relates to the size of the canvas element, but this is the internal size, and it must always be equal to the video size.
