### PR TITLE
Npm intall on windows fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "Ugly",
-  "description": "basic demo for WebChimera.js",
-  "version": "0.1.0",
-  "private": true,
-  "main": "app://host/index.html",
-  "dependencies": {
-    "cmake-js": "*",
-    "wcjs-renderer": "*"
-  },
-  "cmake-js": {
-    "runtime": "nw",
-    "runtimeVersion": "0.12.2"
-  },
-  "env": "development"
+    "name": "Ugly",
+    "description": "basic demo for WebChimera.js",
+    "version": "0.1.0",
+    "private": true,
+    "main": "app://host/index.html",
+    "dependencies": {
+        "cmake-js": "*",
+        "wcjs-renderer": "*"
+    },
+    "cmake-js": {
+        "runtime": "nw",
+        "runtimeVersion": "0.12.2"
+    },
+    "env": "development"
 }

--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
-    "name": "Ugly",
-    "description": "basic demo for WebChimera.js",
-    "version": "0.1.0",
-    "private": true,
-    "main": "app://host/index.html",
-    "dependencies": {
-        "wcjs-renderer": "*"
-    },
-    "cmake-js": {
-        "runtime": "nw",
-        "runtimeVersion": "0.12.2"
-    },
-    "env": "development"
+  "name": "Ugly",
+  "description": "basic demo for WebChimera.js",
+  "version": "0.1.0",
+  "private": true,
+  "main": "app://host/index.html",
+  "dependencies": {
+    "cmake-js": "*",
+    "wcjs-renderer": "*"
+  },
+  "cmake-js": {
+    "runtime": "nw",
+    "runtimeVersion": "0.12.2"
+  },
+  "env": "development"
 }


### PR DESCRIPTION
Npm intall on windows fixed, by adding cmake-js as an immediate dependency. This issue is about that on Windows deeply nested node_modules paths can be too long for execute by the npm cli. The only workaround is decrease nesting by installing modules to the root. Fortunately this is gonna be fixed in npm 3.0.
