### PR TITLE
Updating electron to 1.3.1

### DIFF
--- a/build_electron.cmd
+++ b/build_electron.cmd
@@ -1,5 +1,5 @@
 set npm_config_wcjs_runtime="electron"
-set npm_config_wcjs_runtime_version="0.33.9"
+set npm_config_wcjs_runtime_version="1.3.1"
 rem set npm_config_wcjs_arch="x64"
 set npm_config_wcjs_arch="ia32"
 

--- a/build_electron.sh
+++ b/build_electron.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 export npm_config_wcjs_runtime="electron"
-export npm_config_wcjs_runtime_version="0.33.9"
+export npm_config_wcjs_runtime_version="1.3.1"
 
 npm install

--- a/electron_main.js
+++ b/electron_main.js
@@ -1,8 +1,19 @@
-var BrowserWindow = require('electron').BrowserWindow
-var app = require('electron').app
+// compatible with both Electron 0.x and 1.x
+try {
+  var BrowserWindow = require("browser-window");
+} catch {
+  var BrowserWindow = require("electron").BrowserWindow;
+}
+
+// compatible with both Electron 0.x and 1.x
+try {
+  var app = require("app");
+} catch
+  var app = require("electron").app;
+}
 
 app.on("ready", function() {
-  var win = new BrowserWindow()
-  win.toggleDevTools()
-  win.loadURL("file://" + __dirname + "/index.html")
+  var win = new BrowserWindow();
+  win.toggleDevTools();
+  win.loadURL("file://" + __dirname + "/index.html");
 })

--- a/electron_main.js
+++ b/electron_main.js
@@ -1,8 +1,8 @@
-var app = require("app");
-var BrowserWindow = require("browser-window");
+var BrowserWindow = require('electron').BrowserWindow
+var app = require('electron').app
 
 app.on("ready", function() {
-  var win = new BrowserWindow({});
-  win.toggleDevTools();
-  win.loadUrl("file://" + __dirname + "/index.html");
+  var win = new BrowserWindow()
+  win.toggleDevTools()
+  win.loadURL("file://" + __dirname + "/index.html")
 })


### PR DESCRIPTION
This fixes the demo for electron 1.3.1 which is the latest release that `WebChimera.js` supports.
